### PR TITLE
Add gh-pages dep and deploy scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "deploy": "gh-pages -d dist",
+    "predeploy": "npm run build",
     "preview": "vite preview"
   },
   "devDependencies": {
+    "gh-pages": "^6.3.0",
     "vite": "^6.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
Why
--
- As a user looking to view the project, I should be able to view "prod" at a public URL

How
--
- Add and configure `gh-pages` dependency